### PR TITLE
Increase paragraph text spacing/break size

### DIFF
--- a/main.css
+++ b/main.css
@@ -42,7 +42,7 @@
 	background-color: #2d2d2d;
 	color: white;
 	font-size: 20px;
-	line-height: 40px;
+	line-height: 32px;
 }
 
 #bottom {
@@ -85,6 +85,10 @@ h4 {
 
 a {
 	color: white;
+}
+
+br {
+	margin: 24px
 }
 
 #next-link {


### PR DESCRIPTION
I find some of the longer paragraphs a bit hard to read because of their `line-height` and the lack of spacing between paragraphs (since `<br>`s only add a newline and not a margin).

Here's what the before/after looks like for me.

![spacing](https://user-images.githubusercontent.com/26531118/94340395-b5a1fb80-0044-11eb-8200-d02151cd04cc.jpg)
